### PR TITLE
Change the bitfinex dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-bitfinex
+git+git://github.com/fccoelho/bitfinex.git#egg=bitfinex
 pandas
 backtrader
 keras


### PR DESCRIPTION
We are importing `bitfinex.backtest` in one of the Notebooks, but that module is not available in pip's version of bitfinex package.

This PR just changes bitfinex dependency on requirements.txt to install from github.com/fccoelho/bitfinex, which installs that module and makes it available to use.